### PR TITLE
Fix name for istio canonical service names.

### DIFF
--- a/pkg/defaults/deployment_defaults.go
+++ b/pkg/defaults/deployment_defaults.go
@@ -29,13 +29,11 @@ const (
 	// GroupName is the group name for istio labels and annotations
 	GroupName = "service.istio.io"
 
-	// RevisionLabelKey is the label key attached to k8s resources to indicate
-	// which Revision triggered their creation.
+	// RevisionLabelKey is the label key to define the canonical revision name used by istio.
 	RevisionLabelKey = GroupName + "/canonical-revision"
 
-	// ServiceLabelKey is the label key attached to a Route and Configuration indicating by
-	// which Service they are created.
-	ServiceLabelKey = GroupName + "/canonical-service"
+	// ServiceLabelKey is the label key to define the canonical service name used by istio.
+	ServiceLabelKey = GroupName + "/canonical-name"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/defaults/deployment_defaults_test.go
+++ b/pkg/defaults/deployment_defaults_test.go
@@ -65,15 +65,15 @@ func TestIstioDeploymentDefaulting(t *testing.T) {
 			appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						serving.ServiceLabelKey:              "foo-service",
-						"service.istio.io/canonical-service": "foo-service",
+						serving.ServiceLabelKey:           "foo-service",
+						"service.istio.io/canonical-name": "foo-service",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"service.istio.io/canonical-service": "foo-service",
+								"service.istio.io/canonical-name": "foo-service",
 							},
 						},
 					},
@@ -95,15 +95,15 @@ func TestIstioDeploymentDefaulting(t *testing.T) {
 			appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						serving.ConfigurationLabelKey:        "foo-config",
-						"service.istio.io/canonical-service": "foo-config",
+						serving.ConfigurationLabelKey:     "foo-config",
+						"service.istio.io/canonical-name": "foo-config",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
-								"service.istio.io/canonical-service": "foo-config",
+								"service.istio.io/canonical-name": "foo-config",
 							},
 						},
 					},
@@ -161,7 +161,7 @@ func TestIstioDeploymentDefaulting(t *testing.T) {
 						serving.RevisionLabelKey:              "foo-revision",
 						serving.ServiceLabelKey:               "foo-service",
 						"service.istio.io/canonical-revision": "foo-revision",
-						"service.istio.io/canonical-service":  "foo-service",
+						"service.istio.io/canonical-name":     "foo-service",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
@@ -169,7 +169,7 @@ func TestIstioDeploymentDefaulting(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"service.istio.io/canonical-revision": "foo-revision",
-								"service.istio.io/canonical-service":  "foo-service",
+								"service.istio.io/canonical-name":     "foo-service",
 							},
 						},
 					},


### PR DESCRIPTION
I accidentally copied the wrong label name. The label name is "canonical-name" not "canonical-service":

https://docs.google.com/document/d/1EsKpYNW55-LqG08zdjp1tAd224T9IEG3CEnusmL-Joc/edit#heading=h.lxsagz3b8886.

I have asked about exporting the label strings from istio side. Currently it's exported on pilot, and I don't think this should have a dependency on pilot: https://github.com/istio/istio/blob/2d1b8d6fc2a30787d397770e6f6aa1eec6a46b03/pilot/pkg/model/service.go#L151