### PR TITLE
Remove the cross namespace OwnerReference

### DIFF
--- a/pkg/reconciler/accessor/core/secret.go
+++ b/pkg/reconciler/accessor/core/secret.go
@@ -54,7 +54,7 @@ func ReconcileSecret(ctx context.Context, owner kmeta.Accessor, desired *corev1.
 		recorder.Eventf(owner, corev1.EventTypeNormal, "Created", "Created Secret %s/%s", desired.Namespace, desired.Name)
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to get Secret: %w", err)
-	} else if !metav1.IsControlledBy(secret, owner) {
+	} else if owner != nil && !metav1.IsControlledBy(secret, owner) {
 		// Return an error with NotControlledBy information.
 		return nil, kaccessor.NewAccessorError(
 			fmt.Errorf("owner: %s with Type %T does not own Secret: %s", owner.GetName(), owner, secret.Name),

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -197,9 +197,6 @@ func (r *Reconciler) reconcileCertSecrets(ctx context.Context, ing *v1alpha1.Ing
 			certSecret.Labels[networking.OriginSecretNamespaceLabelKey],
 			certSecret.Labels[networking.OriginSecretNameLabelKey]), ing)
 		if _, err := coreaccessor.ReconcileSecret(ctx, nil, certSecret, r); err != nil {
-			if kaccessor.IsNotOwned(err) {
-				ing.Status.MarkResourceNotOwned("Secret", certSecret.Name)
-			}
 			return err
 		}
 	}

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -140,7 +140,7 @@ func makeIngressGateway(ctx context.Context, ing *v1alpha1.Ingress, originSecret
 }
 
 func getGatewayServices(ctx context.Context, svcLister corev1listers.ServiceLister) ([]*corev1.Service, error) {
-	ingressSvcMetas, err := getIngressGatewaySvcNameNamespaces(ctx)
+	ingressSvcMetas, err := GetIngressGatewaySvcNameNamespaces(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,8 @@ func ServiceNamespaceFromURL(svc string) (string, error) {
 }
 
 // TODO(nghia):  Remove this by parsing at config parsing time.
-func getIngressGatewaySvcNameNamespaces(ctx context.Context) ([]metav1.ObjectMeta, error) {
+// GetIngressGatewaySvcNameNamespaces gets the Istio ingress namespaces from ConfigMap.
+func GetIngressGatewaySvcNameNamespaces(ctx context.Context) ([]metav1.ObjectMeta, error) {
 	cfg := config.FromContext(ctx).Istio
 	nameNamespaces := make([]metav1.ObjectMeta, len(cfg.IngressGateways))
 	for i, ingressgateway := range cfg.IngressGateways {

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -48,7 +48,7 @@ func GetSecrets(ing *v1alpha1.Ingress, secretLister corev1listers.SecretLister) 
 
 // MakeSecrets makes copies of the origin Secrets under the namespace of Istio gateway service.
 func MakeSecrets(ctx context.Context, originSecrets map[string]*corev1.Secret, accessor kmeta.OwnerRefableAccessor) ([]*corev1.Secret, error) {
-	nameNamespaces, err := getIngressGatewaySvcNameNamespaces(ctx)
+	nameNamespaces, err := GetIngressGatewaySvcNameNamespaces(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -71,14 +71,18 @@ func makeSecret(originSecret *corev1.Secret, targetNamespace string, accessor km
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetSecret(originSecret, accessor),
 			Namespace: targetNamespace,
-			Labels: map[string]string{
-				networking.OriginSecretNameLabelKey:      originSecret.Name,
-				networking.OriginSecretNamespaceLabelKey: originSecret.Namespace,
-			},
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(accessor)},
+			Labels:    MakeTargetSecretLabels(originSecret.Name, originSecret.Namespace),
 		},
 		Data: originSecret.Data,
 		Type: originSecret.Type,
+	}
+}
+
+// MakeTargetSecretLabels returns the labels used in target secret.
+func MakeTargetSecretLabels(originSecretName, originSecretNamespace string) map[string]string {
+	return map[string]string{
+		networking.OriginSecretNameLabelKey:      originSecretName,
+		networking.OriginSecretNamespaceLabelKey: originSecretNamespace,
 	}
 }
 

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
 
 	"github.com/google/go-cmp/cmp"
@@ -158,7 +157,6 @@ func TestMakeSecrets(t *testing.T) {
 					networking.OriginSecretNameLabelKey:      "test-secret",
 					networking.OriginSecretNamespaceLabelKey: "knative-serving",
 				},
-				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(&ci)},
 			},
 			Data: map[string][]byte{
 				"test-data": []byte("abcd"),


### PR DESCRIPTION
1. Remove the cross-namespace OwnerReference added when copying secret from user's application namespace to Istio gateway namespace
2. Explicitly delete the secret resources when Ingress is being deleted.

https://github.com/knative/serving/issues/7305