### PR TITLE
Fix log format issue

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -97,7 +97,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ingress *v1alpha1.Ingres
 
 	reconcileErr := r.reconcileIngress(ctx, ingress)
 	if reconcileErr != nil {
-		logger.Errorf("Failed to reconcile Ingress %s", ingress.Name, reconcileErr)
+		logger.Errorf("Failed to reconcile Ingress %s: %v", ingress.Name, reconcileErr)
 		ingress.Status.MarkIngressNotReady(notReconciledReason, notReconciledMessage)
 		return reconcileErr
 	}


### PR DESCRIPTION
This patch make a tiny change to fix log format.
The log missed `%v` so it wrongly prints the log as:

`kubelogs.go:157: E 01:49:53.850 [istio-ingress-controller] [serving-tests/autoscale-sustaining-yjsgcahk] Failed to reconcile Ingress autoscale-sustaining-yjsgcahk%!!(MISSING)(EXTRA *fmt.wrapError=failed to update Gateway: Operation cannot be fulfilled on gateways.networking.istio.io "knative-ingress-gateway": the object has been modified; please apply your changes to the latest version and try again)`