### PR TITLE
Allow trailing dot for gateway service URL

### DIFF
--- a/pkg/reconciler/ingress/config/istio.go
+++ b/pkg/reconciler/ingress/config/istio.go
@@ -88,7 +88,7 @@ func parseGateways(configMap *corev1.ConfigMap, prefix string) ([]Gateway, error
 			continue
 		}
 		gatewayName, serviceURL := k[len(prefix):], v
-		if errs := validation.IsDNS1123Subdomain(serviceURL); len(errs) > 0 {
+		if errs := validation.IsDNS1123Subdomain(strings.TrimSuffix(serviceURL, ".")); len(errs) > 0 {
 			return nil, fmt.Errorf("invalid gateway format: %v", errs)
 		}
 		gatewayNames = append(gatewayNames, gatewayName)

--- a/pkg/reconciler/ingress/config/istio_test.go
+++ b/pkg/reconciler/ingress/config/istio_test.go
@@ -104,6 +104,26 @@ func TestGatewayConfiguration(t *testing.T) {
 			},
 		},
 	}, {
+		name:    "gateway configuration with valid url having a dot at the end",
+		wantErr: false,
+		wantIstio: &Istio{
+			IngressGateways: []Gateway{{
+				Namespace:  "knative-testing",
+				Name:       "knative-ingress-freeway",
+				ServiceURL: "istio-ingressfreeway.istio-system.svc.cluster.local.",
+			}},
+			LocalGateways: defaultLocalGateways(),
+		},
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      IstioConfigName,
+			},
+			Data: map[string]string{
+				"gateway.knative-ingress-freeway": "istio-ingressfreeway.istio-system.svc.cluster.local.",
+			},
+		},
+	}, {
 		name:    "gateway configuration in custom namespace with valid url",
 		wantErr: false,
 		wantIstio: &Istio{


### PR DESCRIPTION
When gateway service URL has the dot at the end, the validation check
fails currently. It should be valid as a FQDNS.

This patch trims the trailing dot to allow service URL has the dot at
the end.

Fixes https://github.com/knative/serving/issues/7415