### PR TITLE
Coalesce the Gateway.spec.servers[] with the same port and protocol

### DIFF
--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -1152,6 +1152,97 @@ func TestListProbeTargets(t *testing.T) {
 				{Scheme: "http", Host: "foo.bar.svc:80"},
 				{Scheme: "http", Host: "foo.bar.svc.cluster.local:80"}},
 		}},
+	}, {
+		name: "two servers, same port, same protocol",
+		ingressGateways: []config.Gateway{{
+			Name:      "gateway",
+			Namespace: "default",
+		}},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: istiov1alpha3.Gateway{
+					Servers: []*istiov1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: &istiov1alpha3.Port{
+							Name:     "http",
+							Number:   80,
+							Protocol: "HTTP",
+						},
+					}, {
+						Hosts: []string{"foo.bar.com"},
+						Port: &istiov1alpha3.Port{
+							Name:     "http",
+							Number:   80,
+							Protocol: "HTTP",
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpointses: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "bogus",
+						Port: 8080,
+					}, {
+						Name: "real",
+						Port: 80,
+					}},
+					Addresses: []v1.EndpointAddress{{
+						IP: "1.1.1.1",
+					}},
+				}},
+			}},
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+					Labels: map[string]string{
+						"gwt": "istio",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "real",
+						Port: 80,
+					}},
+				},
+			}},
+		},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"foo.bar.com",
+					},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				}},
+			},
+		},
+		results: []status.ProbeTarget{{
+			PodIPs:  sets.NewString("1.1.1.1"),
+			PodPort: "80",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
+		}},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/7294

# Benchmark
Setup: 5 Envoy Pods

## Baseline: 1 Host
```
  0.165s The Route is still working to reflect the latest desired specification.
  0.417s Configuration "helloworld-go" is waiting for a Revision to become ready.
  3.182s ...
  3.365s Ingress has not yet been reconciled.
  3.592s Waiting for load balancer to be ready
  4.924s Ready to serve.
```

## Before

### 100 Hosts
```
  0.215s The Route is still working to reflect the latest desired specification.
  0.274s Configuration "helloworld-go" is waiting for a Revision to become ready.
  3.150s ...
  3.354s Ingress has not yet been reconciled.
  3.463s Waiting for load balancer to be ready
 43.610s Ready to serve.
```

### 200 Hosts
```
  0.149s The Route is still working to reflect the latest desired specification.
  0.374s Configuration "helloworld-go" is waiting for a Revision to become ready.
  3.234s ...
  3.428s Ingress has not yet been reconciled.
  3.681s Waiting for load balancer to be ready
 74.153s Ready to serve.
```

### 1000 Hosts
```
  0.183s The Route is still working to reflect the latest desired specification.
  0.717s Configuration "helloworld-go" is waiting for a Revision to become ready.
  3.834s ...
  4.042s Ingress has not yet been reconciled.
  4.960s Waiting for load balancer to be ready
  404.941s Ready to serve.
```

## After

### 100 Hosts
```
  0.473s Configuration "helloworld-go" is waiting for a Revision to become ready.
  2.720s ...
  2.890s Ingress has not yet been reconciled.
  3.642s Waiting for load balancer to be ready
  4.343s Ready to serve.
```

### 200 Hosts
```
  0.471s The Route is still working to reflect the latest desired specification.
  0.495s Configuration "helloworld-go" is waiting for a Revision to become ready.
  2.315s ...
  2.417s Ingress has not yet been reconciled.
  2.827s Waiting for load balancer to be ready
  3.959s Ready to serve.
```

### 1000 Hosts
```
  0.151s The Route is still working to reflect the latest desired specification.                                                                                                                                     
  0.151s Configuration "helloworld-go" is waiting for a Revision to become ready.                                                                                                                                    
  3.220s ...                                                                                                                                                                                                         
  3.459s Ingress has not yet been reconciled.                                                                                                                                                                        
  3.656s Waiting for load balancer to be ready                                                                                                                                                                       
  6.053s Ready to serve.
```

# Next
This won't work if the `servers` are spread across different `Gateways`.

This code has become quite messy and complex through the refactoring/moving/extension. We should rewrite it and handle that scenario: coalesce by `Gateway` (by `Pod` really).