### PR TITLE
ingress: Skip gateway servers with mutual TLS configured

### DIFF
--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
+	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -139,6 +140,10 @@ func (l *gatewayPodTargetLister) listGatewayTargets(gateway *v1alpha3.Gateway) (
 			}
 			tURL.Scheme = "http"
 		case "HTTPS":
+			if server.GetTls().GetMode() == istiov1alpha3.Server_TLSOptions_MUTUAL {
+				l.logger.Infof("Skipping Server %q because HTTPS with TLS mode MUTUAL is not supported", server.Port.Name)
+				continue
+			}
 			tURL.Scheme = "https"
 		default:
 			l.logger.Infof("Skipping Server %q because protocol %q is not supported", server.Port.Name, server.Port.Protocol)

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -431,13 +431,6 @@ func TestListProbeTargets(t *testing.T) {
 							Number:   8080,
 							Protocol: "HTTP",
 						},
-					}, {
-						Hosts: []string{"*"},
-						Port: &istiov1alpha3.Port{
-							Name:     "https",
-							Number:   443,
-							Protocol: "HTTPS",
-						},
 					}},
 					Selector: map[string]string{
 						"gwt": "istio",
@@ -504,6 +497,93 @@ func TestListProbeTargets(t *testing.T) {
 			PodPort: "8080",
 			Port:    "8080",
 			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:8080"}},
+		}},
+	}, {
+		name: "one gateway HTTPS",
+		ingressGateways: []config.Gateway{{
+			Name:      "gateway",
+			Namespace: "default",
+		}},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: istiov1alpha3.Gateway{
+					Servers: []*istiov1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: &istiov1alpha3.Port{
+							Name:     "https",
+							Number:   8443,
+							Protocol: "HTTPS",
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpointses: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "bogus",
+						Port: 8081,
+					}, {
+						Name: "real",
+						Port: 8443,
+					}},
+					Addresses: []v1.EndpointAddress{{
+						IP: "1.1.1.1",
+					}},
+				}},
+			}},
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+					Labels: map[string]string{
+						"gwt": "istio",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "bogus",
+						Port: 8081,
+					}, {
+						Name: "real",
+						Port: 8443,
+					}},
+				},
+			}},
+		},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"foo.bar.com",
+					},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				}},
+			},
+		},
+		results: []status.ProbeTarget{{
+			PodIPs:  sets.NewString("1.1.1.1"),
+			PodPort: "8443",
+			Port:    "8443",
+			URLs:    []*url.URL{{Scheme: "https", Host: "foo.bar.com:8443"}},
 		}},
 	}, {
 		name: "Different port between endpoint and gateway service",


### PR DESCRIPTION
When mutual TLS is configured on the gateway, a probe is attempted, but is rejected because the caller does not have a client certificate present. With the `knative-ingress-gateway` configured like the following:

```yaml
spec:
  selector:
    istio: ingressgateway
  servers:
  - hosts:
    - '*'
    port:
      name: https
      number: 443
      protocol: HTTPS
    tls:
      credentialName: knative-ingress-gateway-tls
      minProtocolVersion: TLSV1_3
      mode: MUTUAL
```

The v0.13.2 networking-istio operator dumps log lines like the following:

```
{
    "level": "error",
    "ts": "2020-04-19T00:47:41.053Z",
    "logger": "istiocontroller.istio-ingress-controller.status-manager",
    "caller": "status/status.go:378",
    "msg": "Probing of https://hello-world-hello-world.ai1.cluster.k8s.local:443 failed, IP: 10.11.57.191:443, ready: false, error: error roundtripping https://hello-world-hello-world.ai1.cluster.k8s.local:443: remote error: tls: alert(116) (depth: 0)",
    "commit": "aa470a6",
    "knative.dev/controller": "istio-ingress-controller",
    "stacktrace": "knative.dev/serving/pkg/network/status.(*Prober).processWorkItem\n\tknative.dev/serving/pkg/network/status/status.go:378\nknative.dev/serving/pkg/network/status.(*Prober).Start.func1\n\tknative.dev/serving/pkg/network/status/status.go:276"
}
```

TLS alert 116 is [`certificate_required`](https://tools.ietf.org/id/draft-ietf-tls-tls13-25.html#rfc.appendix.B.2).

The change is to detect when a gateway is setup for mutual TLS and skip attempting to probe the gateway. In the example above, this will result in 0 probe targets being generated, which is reasonable as this isn't a common or likely "supported" configuration. Regardless, the changes included allow the system to enter a ready state rather than being stuck with `IngressNotConfigured` forever (even though traffic works).