### PR TITLE
Also delete VirtualServices created before Knative 0.12

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -226,8 +226,8 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 
 	// Now, remove the extra ones.
 	selectors := map[string]string{
-		networking.IngressLabelKey: ing.GetName(), // VS created since 0.12
-		serving.RouteLabelKey:      ing.GetName(), // VS created before 0.12
+		networking.IngressLabelKey: ing.GetName(),                          // VS created from 0.12 on
+		serving.RouteLabelKey:      ing.GetLabels()[serving.RouteLabelKey], // VS created before 0.12
 	}
 	for k, v := range selectors {
 		vses, err := r.virtualServiceLister.VirtualServices(ing.GetNamespace()).List(

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -579,7 +579,96 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeNormal, "IngressTypeReconciled", `IngressType reconciled: "test-ns/reconcile-virtualservice"`),
 		},
 		Key: "test-ns/reconcile-virtualservice",
-	}}
+	},
+		{
+			Name: "clean up old VirtualServices with route label and no ingress label",
+			Objects: []runtime.Object{
+				gateway("knative-ingress-gateway", system.Namespace(), []*istiov1alpha3.Server{irrelevantServer1}),
+				gateway("knative-test-gateway", system.Namespace(), []*istiov1alpha3.Server{irrelevantServer1}),
+				&v1alpha1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "reconcile-virtualservice",
+						Namespace: testNS,
+						Labels: map[string]string{
+							serving.RouteLabelKey:          "test-route",
+							serving.RouteNamespaceLabelKey: testNS,
+						},
+						Annotations:     map[string]string{networking.IngressClassAnnotationKey: "some-other-ingress"},
+						ResourceVersion: "v1",
+						Finalizers:      []string{"ingresses.networking.internal.knative.dev"},
+					},
+					Spec: v1alpha1.IngressSpec{
+						DeprecatedGeneration: 1234,
+						Rules:                ingressRules,
+						// Deprecated, needed because of DeepCopy behavior
+						Visibility: v1alpha1.IngressVisibilityExternalIP,
+					},
+				},
+
+				&v1alpha3.VirtualService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "reconcile-virtualservice",
+						Namespace: testNS,
+						Labels: map[string]string{
+							serving.RouteLabelKey: "reconcile-virtualservice",
+						},
+						Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+						OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
+					},
+					Spec: istiov1alpha3.VirtualService{},
+				},
+			},
+			WantDeletes: []clientgotesting.DeleteActionImpl{
+				{
+					ActionImpl: clientgotesting.ActionImpl{
+						Namespace: testNS,
+						Verb:      "delete",
+					},
+					Name: "reconcile-virtualservice",
+				},
+			},
+			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+				Object: addAnnotations(ingressWithFinalizersAndStatus("reconcile-virtualservice", 1234,
+					[]string{"ingresses.networking.internal.knative.dev"},
+					v1alpha1.IngressStatus{
+						LoadBalancer: &v1alpha1.LoadBalancerStatus{
+							Ingress: []v1alpha1.LoadBalancerIngressStatus{
+								{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
+							},
+						},
+						PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+							Ingress: []v1alpha1.LoadBalancerIngressStatus{
+								{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
+							},
+						},
+						PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+							Ingress: []v1alpha1.LoadBalancerIngressStatus{
+								{MeshOnly: true},
+							},
+						},
+						Status: duckv1.Status{
+							Conditions: duckv1.Conditions{{
+								Type:     v1alpha1.IngressConditionLoadBalancerReady,
+								Status:   corev1.ConditionTrue,
+								Severity: apis.ConditionSeverityError,
+							}, {
+								Type:     v1alpha1.IngressConditionNetworkConfigured,
+								Status:   corev1.ConditionTrue,
+								Severity: apis.ConditionSeverityError,
+							}, {
+								Type:     v1alpha1.IngressConditionReady,
+								Status:   corev1.ConditionTrue,
+								Severity: apis.ConditionSeverityError,
+							}},
+						},
+					},
+				), map[string]string{networking.IngressClassAnnotationKey: "some-other-ingress"}),
+			}},
+			WantEvents: []string{
+				Eventf(corev1.EventTypeNormal, "IngressTypeReconciled", `IngressType reconciled: "test-ns/reconcile-virtualservice"`),
+			},
+			Key: "test-ns/reconcile-virtualservice",
+		}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		retryAttempted = false

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -610,7 +610,7 @@ func TestReconcile(t *testing.T) {
 						Name:      "reconcile-virtualservice",
 						Namespace: testNS,
 						Labels: map[string]string{
-							serving.RouteLabelKey: "reconcile-virtualservice",
+							serving.RouteLabelKey: "test-route",
 						},
 						Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
 						OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},


### PR DESCRIPTION
This is to fix the issue that arises if someone migrates from 0.11- to 0.13+.

In Knative 0.13, the way the name of one of the `VirtualService` is derived from the `Ingress` name changed from `{IngressName}` to `{IngressName}-ingress`. The controller is cleaning the old `VirtualService`, see [code](https://github.com/knative/net-istio/blame/master/pkg/reconciler/ingress/ingress.go#L226), but this is done with the label `networking.internal.knative.dev/ingress` which was introduced in 0.12.

As a result, there are two `VirtualService` matching the same requests. Because the way Istio creates the Envoy configuration is not deterministic, which rule is first (and therefore matching) is random. This means that for each `VirtualService` change, there is a 50% chance that the new `VirtualService` is used and "it works" and a 50% chance that the old `VirtualService` is used and then the behavior varies: if the revision is still around, the traffic will go to that revision, if it is not, it will lead to a 503.

The fix would be to also use the label `serving.knative.dev/route` in the selection logic, this way it would handle `VirtualService` created before 0.12.

/cc @tcnghia @Cynocracy @vagababov 