### PR TITLE
Add ingress-provider label to webhook

### DIFF
--- a/config/500-mutating-webhook.yaml
+++ b/config/500-mutating-webhook.yaml
@@ -18,6 +18,7 @@ metadata:
   name: webhook.istio.networking.internal.knative.dev
   labels:
     serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/config/500-validating-webhook.yaml
+++ b/config/500-validating-webhook.yaml
@@ -18,6 +18,7 @@ metadata:
   name: config.webhook.istio.networking.internal.knative.dev
   labels:
     serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/config/500-webhook-secret.yaml
+++ b/config/500-webhook-secret.yaml
@@ -19,3 +19,4 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio

--- a/config/webhook-deployment.yaml
+++ b/config/webhook-deployment.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
 spec:
   selector:
     matchLabels:

--- a/config/webhook-service.yaml
+++ b/config/webhook-service.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     role: istio-webhook
     serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
 spec:
   ports:
   # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
This patch adds the label `networking.knative.dev/ingress-provider: istio` to webhook resources.
As the `net-istio.yaml` in the [serving project](https://github.com/knative/serving/blob/e315571c47686a17f622e0fd29552baaedde07b0/config/net-istio.yaml) does not have the label in webhook resources, it installs them unexpectedly:

```
$ cd $GOPATH/src/knative.dev/serving
$ ko apply -f config/ --selector=networking.knative.dev/ingress-provider!=istio
  ...
mutatingwebhookconfiguration.admissionregistration.k8s.io/webhook.istio.networking.internal.knative.dev created
validatingwebhookconfiguration.admissionregistration.k8s.io/config.webhook.istio.networking.internal.knative.dev created
secret/istio-webhook-certs created
deployment.apps/istio-webhook created
service/istio-webhook created
```

`istio-webhook` should be necessary only for Istio ingress.