### PR TITLE
Fix presubmit tests to use vendor and have all images.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/net-istio
 
-go 1.13
+go 1.14
 
 require (
 	github.com/gobuffalo/envy v1.9.0 // indirect

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -26,6 +26,7 @@ import (
 	_ "knative.dev/serving/test/conformance/ingress"
 	_ "knative.dev/serving/test/test_images/flaky"
 	_ "knative.dev/serving/test/test_images/grpc-ping"
+	_ "knative.dev/serving/test/test_images/helloworld"
 	_ "knative.dev/serving/test/test_images/httpproxy"
 	_ "knative.dev/serving/test/test_images/runtime"
 	_ "knative.dev/serving/test/test_images/timeout"

--- a/vendor/knative.dev/serving/test/test_images/helloworld/README.md
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/README.md
@@ -1,0 +1,23 @@
+# Helloworld test image
+
+This directory contains the test image used in the helloworld e2e test.
+
+The image contains a simple Go webserver, `helloworld.go`, that will, by
+default, listen on port `8080` and expose a service at `/`.
+
+When called, the server emits a "hello world" message.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+To run this image as just a Route and Configuration:
+
+`ko apply -f helloworld.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.go
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"knative.dev/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Hello world received a request.")
+	fmt.Fprintln(w, "Hello World! How about some tasty noodles?")
+}
+
+func main() {
+	flag.Parse()
+	log.Print("Hello world app started.")
+
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.yaml
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.yaml
@@ -1,0 +1,40 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Configuration
+metadata:
+  name: configuration-example
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - # This is the Go import path for the binary to containerize
+        # and substitute here.
+        image: ko://knative.dev/serving/test/test_images/helloworld
+        readinessProbe:
+          httpGet:
+            path: /
+          initialDelaySeconds: 3
+---
+apiVersion: serving.knative.dev/v1
+kind: Route
+metadata:
+  name: route-example
+  namespace: default
+spec:
+  traffic:
+  - configurationName: configuration-example
+    percent: 100

--- a/vendor/knative.dev/serving/test/test_images/helloworld/service.yaml
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/helloworld

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -81,8 +81,10 @@ github.com/go-openapi/spec
 # github.com/go-openapi/swag v0.19.7
 github.com/go-openapi/swag
 # github.com/gobuffalo/envy v1.9.0
+## explicit
 github.com/gobuffalo/envy
 # github.com/gogo/protobuf v1.3.1
+## explicit
 github.com/gogo/protobuf/gogoproto
 github.com/gogo/protobuf/jsonpb
 github.com/gogo/protobuf/proto
@@ -104,6 +106,7 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/go-cmp v0.4.0
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -130,6 +133,7 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gorilla/websocket v1.4.1
+## explicit
 github.com/gorilla/websocket
 # github.com/grpc-ecosystem/grpc-gateway v1.12.2
 github.com/grpc-ecosystem/grpc-gateway/internal
@@ -179,6 +183,7 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/rogpeppe/go-internal v1.5.2
+## explicit
 github.com/rogpeppe/go-internal/modfile
 github.com/rogpeppe/go-internal/module
 github.com/rogpeppe/go-internal/semver
@@ -211,6 +216,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.5.0
 go.uber.org/multierr
 # go.uber.org/zap v1.14.1
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -241,6 +247,7 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775
@@ -265,6 +272,7 @@ golang.org/x/tools/internal/imports
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.1.0
+## explicit
 gomodules.xyz/jsonpatch/v2
 # gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485
 gonum.org/v1/gonum/blas
@@ -379,12 +387,15 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # istio.io/api v0.0.0-20200107183329-ed4b507c54e1
+## explicit
 istio.io/api/networking/v1alpha3
 # istio.io/client-go v0.0.0-20200107185429-9053b0f86b03
+## explicit
 istio.io/client-go/pkg/apis/networking/v1alpha3
 # istio.io/gogo-genproto v0.0.0-20191029161641-f7d19ec0141d
 istio.io/gogo-genproto/googleapis/google/api
 # k8s.io/api v0.17.4 => k8s.io/api v0.16.4
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -428,6 +439,7 @@ k8s.io/api/storage/v1beta1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.17.4 => k8s.io/apimachinery v0.16.4
+## explicit
 k8s.io/apimachinery/pkg/api/apitesting/fuzzer
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -476,6 +488,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible => k8s.io/client-go v0.16.4
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
@@ -740,6 +753,7 @@ k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # knative.dev/pkg v0.0.0-20200506001744-478962f05e2b
+## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
 knative.dev/pkg/apis/duck/v1
@@ -806,6 +820,7 @@ knative.dev/pkg/webhook/configmaps
 knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 # knative.dev/serving v0.14.1-0.20200506074444-bddc388e671c
+## explicit
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1
 knative.dev/serving/pkg/apis/config
@@ -876,6 +891,7 @@ knative.dev/serving/test/e2e
 knative.dev/serving/test/test_images/flaky
 knative.dev/serving/test/test_images/grpc-ping
 knative.dev/serving/test/test_images/grpc-ping/proto
+knative.dev/serving/test/test_images/helloworld
 knative.dev/serving/test/test_images/httpproxy
 knative.dev/serving/test/test_images/runtime
 knative.dev/serving/test/test_images/runtime/handlers
@@ -885,7 +901,14 @@ knative.dev/serving/test/types
 knative.dev/serving/test/v1
 knative.dev/serving/test/v1alpha1
 # knative.dev/test-infra v0.0.0-20200506045344-e71b1288c15c
+## explicit
 knative.dev/test-infra/scripts
 knative.dev/test-infra/tools/dep-collector
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml
+# github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
+# k8s.io/api => k8s.io/api v0.16.4
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.4
+# k8s.io/apimachinery => k8s.io/apimachinery v0.16.4
+# k8s.io/client-go => k8s.io/client-go v0.16.4
+# k8s.io/code-generator => k8s.io/code-generator v0.16.4


### PR DESCRIPTION
This moves go.mod to go 1.14 to automatically detect the vendor directory. It also adds the missing helloworld image to make tests pass again. Without it, `upload-test-image.sh` will fail.