### PR TITLE
Add Gateway related helper functions for generating Gateway for wildcard certificate

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -137,7 +137,7 @@ func makeWildcardGateways(ctx context.Context, originWildcardSecrets map[string]
 		}
 		// If the origin secret is not in the target namespace, then it should have been
 		// copied into the target namespace. So we use the name of the copy.
-		credentialName := wildcardSecretName(secret.Name, secret.Namespace)
+		credentialName := targetWildcardSecretName(secret.Name, secret.Namespace)
 		if secret.Namespace == gatewayService.Namespace {
 			credentialName = secret.Name
 		}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -577,7 +577,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
 						ServerCertificate: corev1.TLSCertKey,
 						PrivateKey:        corev1.TLSPrivateKeyKey,
-						CredentialName:    wildcardSecretName(wildcardSecret.Name, wildcardSecret.Namespace),
+						CredentialName:    targetWildcardSecretName(wildcardSecret.Name, wildcardSecret.Namespace),
 					},
 				}, {
 					Hosts: []string{"*.example.com"},

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -51,6 +51,12 @@ var secret = corev1.Secret{
 	},
 }
 
+var wildcardSecret, _ = generateCertificate("*.example.com", "secret0", system.Namespace())
+
+var wildcardSecrets = map[string]*corev1.Secret{
+	fmt.Sprintf("%s/secret0", system.Namespace()): wildcardSecret,
+}
+
 var originSecrets = map[string]*corev1.Secret{
 	fmt.Sprintf("%s/secret0", system.Namespace()): &secret,
 }
@@ -530,6 +536,154 @@ func TestUpdateGateway(t *testing.T) {
 				t.Errorf("Unexpected gateway (-want, +got): %v", diff)
 			}
 		})
+	}
+}
+
+func TestMakeWildcardGateways(t *testing.T) {
+	testCases := []struct {
+		name            string
+		wildcardSecrets map[string]*corev1.Secret
+		gatewayService  *corev1.Service
+		want            []*v1alpha3.Gateway
+		wantErr         bool
+	}{{
+		name:            "happy path: secret namespace is the different from the gateway service namespace",
+		wildcardSecrets: wildcardSecrets,
+		gatewayService: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "istio-system",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: selector,
+			},
+		},
+		want: []*v1alpha3.Gateway{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            WildcardGatewayName(wildcardSecret.Name, "istio-system", "istio-ingressgateway"),
+				Namespace:       system.Namespace(),
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, wildcardSecret.GroupVersionKind())},
+			},
+			Spec: istiov1alpha3.Gateway{
+				Selector: selector,
+				Servers: []*istiov1alpha3.Server{{
+					Hosts: []string{"*.example.com"},
+					Port: &istiov1alpha3.Port{
+						Name:     "https",
+						Number:   443,
+						Protocol: "HTTPS",
+					},
+					Tls: &istiov1alpha3.Server_TLSOptions{
+						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
+						CredentialName:    wildcardSecretName(wildcardSecret.Name, wildcardSecret.Namespace),
+					},
+				}, {
+					Hosts: []string{"*.example.com"},
+					Port: &istiov1alpha3.Port{
+						Name:     httpServerPortName,
+						Number:   80,
+						Protocol: "HTTP",
+					},
+				}},
+			},
+		}},
+	}, {
+		name:            "happy path: secret namespace is the same as the gateway service namespace",
+		wildcardSecrets: wildcardSecrets,
+		gatewayService: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: system.Namespace(),
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: selector,
+			},
+		},
+		want: []*v1alpha3.Gateway{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            WildcardGatewayName(wildcardSecret.Name, system.Namespace(), "istio-ingressgateway"),
+				Namespace:       system.Namespace(),
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(wildcardSecret, wildcardSecret.GroupVersionKind())},
+			},
+			Spec: istiov1alpha3.Gateway{
+				Selector: selector,
+				Servers: []*istiov1alpha3.Server{{
+					Hosts: []string{"*.example.com"},
+					Port: &istiov1alpha3.Port{
+						Name:     "https",
+						Number:   443,
+						Protocol: "HTTPS",
+					},
+					Tls: &istiov1alpha3.Server_TLSOptions{
+						Mode:              istiov1alpha3.Server_TLSOptions_SIMPLE,
+						ServerCertificate: corev1.TLSCertKey,
+						PrivateKey:        corev1.TLSPrivateKeyKey,
+						CredentialName:    wildcardSecret.Name,
+					},
+				}, {
+					Hosts: []string{"*.example.com"},
+					Port: &istiov1alpha3.Port{
+						Name:     httpServerPortName,
+						Number:   80,
+						Protocol: "HTTP",
+					},
+				}},
+			},
+		}},
+	}, {
+		name:            "error to make gateway because of incorrect originSecrets",
+		wildcardSecrets: map[string]*corev1.Secret{"": &secret},
+		gatewayService: &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "istio-ingressgateway",
+				Namespace: "istio-system",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: selector,
+			},
+		},
+		wantErr: true,
+	}}
+
+	for _, tc := range testCases {
+		ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+		defer cancel()
+		svcLister := serviceLister(ctx, tc.gatewayService)
+		ctx = config.ToContext(context.Background(), &config.Config{
+			Istio: &config.Istio{
+				IngressGateways: []config.Gateway{{
+					Name:       networking.KnativeIngressGateway,
+					ServiceURL: fmt.Sprintf("%s.%s.svc.cluster.local", tc.gatewayService.Name, tc.gatewayService.Namespace),
+				}},
+			},
+			Network: &network.Config{
+				HTTPProtocol: network.HTTPEnabled,
+			},
+		})
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := MakeWildcardGateways(ctx, tc.wildcardSecrets, svcLister)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Test: %s; MakeWildcardGateways error = %v, WantErr %v", tc.name, err, tc.wantErr)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected Gateways (-want, +got): %v", diff)
+			}
+		})
+	}
+}
+
+func TestGetQualifiedGatewayNames(t *testing.T) {
+	gateways := []*v1alpha3.Gateway{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istio-ingress-gateway",
+			Namespace: "knative-serving",
+		},
+	}}
+	want := []string{"knative-serving/istio-ingress-gateway"}
+	if got := GetQualifiedGatewayNames(gateways); cmp.Diff(want, got) != "" {
+		t.Fatalf("GetQualifiedGatewayNames failed. Want: %v, got: %v", want, got)
 	}
 }
 

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -85,13 +85,13 @@ func MakeWildcardSecrets(ctx context.Context, originWildcardCerts map[string]*co
 				// as the origin namespace
 				continue
 			}
-			secrets = append(secrets, makeSecret(secret, wildcardSecretName(secret.Name, secret.Namespace), meta.Namespace, map[string]string{}))
+			secrets = append(secrets, makeSecret(secret, targetWildcardSecretName(secret.Name, secret.Namespace), meta.Namespace, map[string]string{}))
 		}
 	}
 	return secrets, nil
 }
 
-func wildcardSecretName(originSecretName, originSecretNamespace string) string {
+func targetWildcardSecretName(originSecretName, originSecretNamespace string) string {
 	return originSecretNamespace + "--" + originSecretName + "-wildcard"
 }
 

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -85,10 +85,14 @@ func MakeWildcardSecrets(ctx context.Context, originWildcardCerts map[string]*co
 				// as the origin namespace
 				continue
 			}
-			secrets = append(secrets, makeSecret(secret, secret.Name, meta.Namespace, map[string]string{}))
+			secrets = append(secrets, makeSecret(secret, wildcardSecretName(secret.Name, secret.Namespace), meta.Namespace, map[string]string{}))
 		}
 	}
 	return secrets, nil
+}
+
+func wildcardSecretName(originSecretName, originSecretNamespace string) string {
+	return originSecretNamespace + "--" + originSecretName + "-wildcard"
 }
 
 func makeSecret(originSecret *corev1.Secret, name, namespace string, labels map[string]string) *corev1.Secret {

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -235,7 +235,7 @@ func TestMakeWildcardSecrets(t *testing.T) {
 			}},
 		expected: []*corev1.Secret{{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: wildcardSecretName("test-secret", "knative-serving"),
+				Name: targetWildcardSecretName("test-secret", "knative-serving"),
 				// Expected secret should be in istio-system which is
 				// the ns of Istio gateway service.
 				Namespace: "istio-system",

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -67,8 +67,8 @@ var (
 		},
 	}
 
-	wildcardCert, _    = generateCertificate("*.example.com", "wildcard")
-	nonWildcardCert, _ = generateCertificate("test.example.com", "nonWildcard")
+	wildcardCert, _    = generateCertificate("*.example.com", "wildcard", "")
+	nonWildcardCert, _ = generateCertificate("test.example.com", "nonWildcard", "")
 )
 
 func TestGetSecrets(t *testing.T) {
@@ -235,7 +235,7 @@ func TestMakeWildcardSecrets(t *testing.T) {
 			}},
 		expected: []*corev1.Secret{{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-secret",
+				Name: wildcardSecretName("test-secret", "knative-serving"),
 				// Expected secret should be in istio-system which is
 				// the ns of Istio gateway service.
 				Namespace: "istio-system",
@@ -335,7 +335,7 @@ func TestGetHostsFromCertSecret(t *testing.T) {
 	}
 }
 
-func generateCertificate(host string, secretName string) (*corev1.Secret, error) {
+func generateCertificate(host string, secretName string, namespace string) (*corev1.Secret, error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate private key: %v", err)
@@ -386,7 +386,8 @@ func generateCertificate(host string, secretName string) (*corev1.Secret, error)
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: secretName,
+			Name:      secretName,
+			Namespace: namespace,
 		},
 		Data: map[string][]byte{
 			corev1.TLSCertKey:       certBuf.Bytes(),


### PR DESCRIPTION
Context: https://github.com/knative/serving/issues/7495#issuecomment-609369477

For Ingresses sharing a wildcard certificate, they need to be tied to a Gateway with the wildcard host.

This PR adds the helper function to generate wildcard Gateway with the given wildcard certificate secret.