### PR TITLE
Backport "Coalescing the Gateway.spec.servers[]" #67 to the 0.14 branch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1183,7 +1183,7 @@
 
 [[projects]]
   branch = "release-0.14"
-  digest = "1:f806eb7e5629d594362dc18905d092888b1d56fbfe026a597d25b86e846f2d53"
+  digest = "1:8b6fc008c0812bf9aa046747c03366415274bfb66475aa201701c904fac5fb18"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1252,11 +1252,11 @@
     "webhook/resourcesemantics/defaulting",
   ]
   pruneopts = "T"
-  revision = "2a1db869228ceaca9df34790b49cdf4893a5d39d"
+  revision = "7b6bb61326aec4bb26625da0d24a1ac3d1122950"
 
 [[projects]]
   branch = "release-0.14"
-  digest = "1:9f503c04b1253ff9a61091004a0c7e35e17f460bd9cd918bd9e68552f1610dff"
+  digest = "1:08ae6d731a3848402c005461c74289f99babd6b1c5f2a875cd23079294e3d2b0"
   name = "knative.dev/serving"
   packages = [
     "pkg/apis/autoscaling",
@@ -1328,6 +1328,7 @@
     "test/test_images/flaky",
     "test/test_images/grpc-ping",
     "test/test_images/grpc-ping/proto",
+    "test/test_images/helloworld",
     "test/test_images/httpproxy",
     "test/test_images/runtime",
     "test/test_images/runtime/handlers",
@@ -1338,7 +1339,7 @@
     "test/v1alpha1",
   ]
   pruneopts = "U"
-  revision = "f87352b72c48286f164838ddc6684c805ea082a9"
+  revision = "4f12c1fec52f6aaa3a383fa0164c3cfa7c4faa8d"
 
 [[projects]]
   branch = "release-0.14"
@@ -1462,6 +1463,7 @@
     "knative.dev/serving/test/e2e",
     "knative.dev/serving/test/test_images/flaky",
     "knative.dev/serving/test/test_images/grpc-ping",
+    "knative.dev/serving/test/test_images/helloworld",
     "knative.dev/serving/test/test_images/httpproxy",
     "knative.dev/serving/test/test_images/runtime",
     "knative.dev/serving/test/test_images/timeout",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,6 +10,7 @@ required = [
   "knative.dev/pkg/codegen/cmd/injection-gen",
   "knative.dev/serving/test/conformance/ingress",
   "knative.dev/serving/test/test_images/flaky",
+  "knative.dev/serving/test/test_images/helloworld",
   "knative.dev/serving/test/test_images/grpc-ping",
   "knative.dev/serving/test/test_images/httpproxy",
   "knative.dev/serving/test/test_images/runtime",

--- a/pkg/reconciler/ingress/lister_test.go
+++ b/pkg/reconciler/ingress/lister_test.go
@@ -1152,6 +1152,97 @@ func TestListProbeTargets(t *testing.T) {
 				{Scheme: "http", Host: "foo.bar.svc:80"},
 				{Scheme: "http", Host: "foo.bar.svc.cluster.local:80"}},
 		}},
+	}, {
+		name: "two servers, same port, same protocol",
+		ingressGateways: []config.Gateway{{
+			Name:      "gateway",
+			Namespace: "default",
+		}},
+		gatewayLister: &fakeGatewayLister{
+			gateways: []*v1alpha3.Gateway{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Spec: istiov1alpha3.Gateway{
+					Servers: []*istiov1alpha3.Server{{
+						Hosts: []string{"*"},
+						Port: &istiov1alpha3.Port{
+							Name:     "http",
+							Number:   80,
+							Protocol: "HTTP",
+						},
+					}, {
+						Hosts: []string{"foo.bar.com"},
+						Port: &istiov1alpha3.Port{
+							Name:     "http",
+							Number:   80,
+							Protocol: "HTTP",
+						},
+					}},
+					Selector: map[string]string{
+						"gwt": "istio",
+					},
+				},
+			}},
+		},
+		endpointsLister: &fakeEndpointsLister{
+			endpointses: []*v1.Endpoints{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Ports: []v1.EndpointPort{{
+						Name: "bogus",
+						Port: 8080,
+					}, {
+						Name: "real",
+						Port: 80,
+					}},
+					Addresses: []v1.EndpointAddress{{
+						IP: "1.1.1.1",
+					}},
+				}},
+			}},
+		},
+		serviceLister: &fakeServiceLister{
+			services: []*v1.Service{{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gateway",
+					Labels: map[string]string{
+						"gwt": "istio",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{{
+						Name: "real",
+						Port: 80,
+					}},
+				},
+			}},
+		},
+		ingress: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "whatever",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{
+						"foo.bar.com",
+					},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				}},
+			},
+		},
+		results: []status.ProbeTarget{{
+			PodIPs:  sets.NewString("1.1.1.1"),
+			PodPort: "80",
+			Port:    "80",
+			URLs:    []*url.URL{{Scheme: "http", Host: "foo.bar.com:80"}},
+		}},
 	}}
 
 	for _, test := range tests {

--- a/vendor/knative.dev/pkg/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
+++ b/vendor/knative.dev/pkg/client/injection/apiextensions/reconciler/apiextensions/v1beta1/customresourcedefinition/reconciler.go
@@ -137,7 +137,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	if errors.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Errorf("resource %q no longer exists", key)
+		logger.Debugf("resource %q no longer exists", key)
 		return nil
 	} else if err != nil {
 		return err

--- a/vendor/knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/vendor/knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -136,7 +136,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	if errors.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Errorf("resource %q no longer exists", key)
+		logger.Debugf("resource %q no longer exists", key)
 		return nil
 	} else if err != nil {
 		return err

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -270,7 +270,7 @@ func (r *reconcilerImpl) Reconcile(ctx {{.contextContext|raw}}, key string) erro
 
 	if {{.apierrsIsNotFound|raw}}(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Errorf("resource %q no longer exists", key)
+		logger.Debugf("resource %q no longer exists", key)
 		return nil
 	} else if err != nil {
 		return err

--- a/vendor/knative.dev/serving/pkg/apis/serving/v1/route_validation.go
+++ b/vendor/knative.dev/serving/pkg/apis/serving/v1/route_validation.go
@@ -62,7 +62,11 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 		if tt.Tag == "" {
 			continue
 		}
-
+		if msgs := validation.IsDNS1035Label(tt.Tag); len(msgs) > 0 {
+			errs = errs.Also(apis.ErrInvalidArrayValue(
+				fmt.Sprintf("not a DNS 1035 label: %v", msgs),
+				"tag", i))
+		}
 		if idx, ok := trafficMap[tt.Tag]; ok {
 			// We want only single definition of the route, even if it points
 			// to the same config or revision.

--- a/vendor/knative.dev/serving/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
+++ b/vendor/knative.dev/serving/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
@@ -137,7 +137,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	if errors.IsNotFound(err) {
 		// The resource may no longer exist, in which case we stop processing.
-		logger.Errorf("resource %q no longer exists", key)
+		logger.Debugf("resource %q no longer exists", key)
 		return nil
 	} else if err != nil {
 		return err

--- a/vendor/knative.dev/serving/test/test_images/helloworld/README.md
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/README.md
@@ -1,0 +1,23 @@
+# Helloworld test image
+
+This directory contains the test image used in the helloworld e2e test.
+
+The image contains a simple Go webserver, `helloworld.go`, that will, by
+default, listen on port `8080` and expose a service at `/`.
+
+When called, the server emits a "hello world" message.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+To run this image as just a Route and Configuration:
+
+`ko apply -f helloworld.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.go
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"knative.dev/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Hello world received a request.")
+	fmt.Fprintln(w, "Hello World! How about some tasty noodles?")
+}
+
+func main() {
+	flag.Parse()
+	log.Print("Hello world app started.")
+
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.yaml
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.yaml
@@ -1,0 +1,40 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Configuration
+metadata:
+  name: configuration-example
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - # This is the Go import path for the binary to containerize
+        # and substitute here.
+        image: ko://knative.dev/serving/test/test_images/helloworld
+        readinessProbe:
+          httpGet:
+            path: /
+          initialDelaySeconds: 3
+---
+apiVersion: serving.knative.dev/v1
+kind: Route
+metadata:
+  name: route-example
+  namespace: default
+spec:
+  traffic:
+  - configurationName: configuration-example
+    percent: 100

--- a/vendor/knative.dev/serving/test/test_images/helloworld/service.yaml
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/helloworld


### PR DESCRIPTION
This PR ports the changes from #67 back to the 0.14 branch to make the performance improvements available in Knative 0.14.x