### PR TITLE
Add HA label to ha deployments

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     networking.knative.dev/ingress-provider: istio
+    knative.dev/high-availability: "true"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Similar to  https://github.com/knative/serving/pull/8297

As per https://github.com/knative/operator/issues/73, indicate the HA deployments

## Proposed Changes
- Indicate the HA deployments that are installed by the operator

Operator PR that will allow the operator to read the label: https://github.com/knative/operator/pull/134