### PR TITLE
Exclude the webhook from the mesh.

### DIFF
--- a/config/webhook-deployment.yaml
+++ b/config/webhook-deployment.yaml
@@ -29,6 +29,9 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        # This must be outside of the mesh to be reachable by
+        # kube-api (also outside the mesh).
+        sidecar.istio.io/inject: "false"
       labels:
         app: istio-webhook
         role: istio-webhook


### PR DESCRIPTION
Fixes #150 

Right now, testing doesn't cover this, but it will be covered once we move to Istio 1.5 and enable mTLS Strict.
Context: https://github.com/knative/serving/pull/5648

/assign @nak3 