### PR TITLE
Explicitly set retry attempt to 0 when no retries are configured in ingress

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -220,6 +220,11 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 			route.Retries.PerTryTimeout = types.DurationProto(http.Retries.PerTryTimeout.Duration)
 		}
 	}
+	if http.Retries == nil || http.Retries.Attempts == 0 {
+		route.Retries = &istiov1alpha3.HTTPRetry{
+			Attempts: 0,
+		}
+	}
 	return route
 }
 

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -219,8 +219,7 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 		if http.Retries.PerTryTimeout != nil {
 			route.Retries.PerTryTimeout = types.DurationProto(http.Retries.PerTryTimeout.Duration)
 		}
-	}
-	if http.Retries == nil || http.Retries.Attempts == 0 {
+	} else {
 		route.Retries = &istiov1alpha3.HTTPRetry{
 			Attempts: 0,
 		}

--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -211,6 +211,7 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 		Headers: h,
 	}
 
+	route.Retries = &istiov1alpha3.HTTPRetry{}
 	if http.Retries != nil && http.Retries.Attempts > 0 {
 		route.Retries = &istiov1alpha3.HTTPRetry{
 			RetryOn:  retriableConditions,
@@ -218,10 +219,6 @@ func makeVirtualServiceRoute(hosts sets.String, http *v1alpha1.HTTPIngressPath, 
 		}
 		if http.Retries.PerTryTimeout != nil {
 			route.Retries.PerTryTimeout = types.DurationProto(http.Retries.PerTryTimeout.Duration)
-		}
-	} else {
-		route.Retries = &istiov1alpha3.HTTPRetry{
-			Attempts: 0,
 		}
 	}
 	return route

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -465,9 +465,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRetries(t *testing.T) {
 					},
 				}}},
 		},
-		expected: &istiov1alpha3.HTTPRetry{
-			Attempts: 0,
-		},
+		expected: &istiov1alpha3.HTTPRetry{},
 	}, {
 		name: "disabling retries",
 		ci: &v1alpha1.Ingress{
@@ -492,9 +490,7 @@ func TestMakeMeshVirtualServiceSpec_CorrectRetries(t *testing.T) {
 					},
 				}}},
 		},
-		expected: &istiov1alpha3.HTTPRetry{
-			Attempts: 0,
-		},
+		expected: &istiov1alpha3.HTTPRetry{},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, h := range MakeMeshVirtualService(tc.ci, defaultGateways).Spec.Http {

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -465,7 +465,9 @@ func TestMakeMeshVirtualServiceSpec_CorrectRetries(t *testing.T) {
 					},
 				}}},
 		},
-		expected: nil,
+		expected: &istiov1alpha3.HTTPRetry{
+			Attempts: 0,
+		},
 	}, {
 		name: "disabling retries",
 		ci: &v1alpha1.Ingress{
@@ -490,7 +492,9 @@ func TestMakeMeshVirtualServiceSpec_CorrectRetries(t *testing.T) {
 					},
 				}}},
 		},
-		expected: nil,
+		expected: &istiov1alpha3.HTTPRetry{
+			Attempts: 0,
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, h := range MakeMeshVirtualService(tc.ci, defaultGateways).Spec.Http {


### PR DESCRIPTION
This patch changes to set `istiov1alpha3.HTTPRetry.Attempts` to 0 when
no retries are configued or attempts are set to 0.

Istio tries to retry twice before returning the error by
default. Please refer to the following istio doc:

https://istio.io/latest/docs/concepts/traffic-management/#retries
> The default retry behavior for HTTP requests is to retry twice before returning the error.

fix https://github.com/knative/serving/issues/6549